### PR TITLE
Call specific GKE version in release channel

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@
 module "gke" {
   source                     = "terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster"
   version                    = "15.0.1"
-  kubernetes_version         = "1.22"
+  kubernetes_version         = "1.22.8-gke.202"
   project_id                 = var.project_id
   name                       = var.cluster_name
   regional                   = var.regional

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@
 # Create the GKE Cluster
 module "gke" {
   source                     = "terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster"
-  version                    = "15.0.1"
+  version                    = "18.0.0"
   kubernetes_version         = "1.22.8-gke.202"
   project_id                 = var.project_id
   name                       = var.cluster_name


### PR DESCRIPTION
This PR calls a specific GKE version as defined by the API, as opposed to a generic "1.22" string